### PR TITLE
New release: Bitmap serialization as a compressed byte array

### DIFF
--- a/TostSerializer-Tests.package/TostMaterializationTests.class/instance/testBitmapInstance.st
+++ b/TostSerializer-Tests.package/TostMaterializationTests.class/instance/testBitmapInstance.st
@@ -1,0 +1,10 @@
+tests-objects
+testBitmapInstance
+
+	| actual |
+	self serialize: (Bitmap withAll: #(1 2 5 10)).
+	
+	actual := materializer materializeObject.
+	
+	actual should beInstanceOf: Bitmap.
+	actual should equalInOrder: #(1 2 5 10)

--- a/TostSerializer.package/Bitmap.extension/class/createTostInstanceWith..st
+++ b/TostSerializer.package/Bitmap.extension/class/createTostInstanceWith..st
@@ -1,0 +1,5 @@
+*TostSerializer
+createTostInstanceWith: aTostMaterialization
+	| bytes |
+	bytes := ByteArray createTostInstanceWith: aTostMaterialization.
+	^Bitmap decompressFromByteArray: bytes

--- a/TostSerializer.package/Bitmap.extension/instance/writeTostBodyWith..st
+++ b/TostSerializer.package/Bitmap.extension/instance/writeTostBodyWith..st
@@ -1,0 +1,3 @@
+*TostSerializer
+writeTostBodyWith: aTostSerialization
+	self compressToByteArray writeTostBodyWith: aTostSerialization

--- a/TostSerializer.package/Bitmap.extension/properties.json
+++ b/TostSerializer.package/Bitmap.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "Bitmap"
+}


### PR DESCRIPTION
There was incomplete implementation of Bitmap transport:
Bitmap is a whole object without references and it must implement specific serialization methods.
 
Bitmap provides suitable methods to compression/decompression to/from bytearray. So it was simplest way to get bytes for serialization. 