### PR TITLE
Pharo9 deprecation methods

### DIFF
--- a/TostSerializer-Tests/TostMaterializationTests.class.st
+++ b/TostSerializer-Tests/TostMaterializationTests.class.st
@@ -5,7 +5,7 @@ Class {
 		'materializer',
 		'binaryData'
 	],
-	#category : 'TostSerializer-Tests'
+	#category : #'TostSerializer-Tests'
 }
 
 { #category : #helpers }
@@ -484,34 +484,39 @@ TostMaterializationTests >> testReadingOneByteInteger [
 
 { #category : #'tests-primitive data' }
 TostMaterializationTests >> testReadingTwoBytesInteger [
-
 	| actual |
-	self binaryData: {2. 0. 300 digitAt: 2. 300 digitAt: 1}.
-	
+	self
+		binaryData:
+			{2.
+			0.
+			(300 byteAt: 2).
+			(300 byteAt: 1)}.
 	actual := materializer readInteger.
-	
 	actual should equal: 300
 ]
 
 { #category : #'tests-primitive data' }
 TostMaterializationTests >> testReadingTwoBytesNegativeInteger [
-
 	| actual |
-	self binaryData: {2. 1. 300 digitAt: 2. 300 digitAt: 1}.
-	
+	self
+		binaryData:
+			{2.
+			1.
+			(300 byteAt: 2).
+			(300 byteAt: 1)}.
 	actual := materializer readInteger.
-	
 	actual should equal: -300
 ]
 
 { #category : #'tests-primitive data' }
 TostMaterializationTests >> testReadingTwoBytesPositiveInteger [
-
 	| actual |
-	self binaryData: {2. 300 digitAt: 2. 300 digitAt: 1}.
-	
+	self
+		binaryData:
+			{2.
+			(300 byteAt: 2).
+			(300 byteAt: 1)}.
 	actual := materializer readPositiveInteger.
-	
 	actual should equal: 300
 ]
 

--- a/TostSerializer-Tests/TostMaterializationTests.class.st
+++ b/TostSerializer-Tests/TostMaterializationTests.class.st
@@ -485,12 +485,7 @@ TostMaterializationTests >> testReadingOneByteInteger [
 { #category : #'tests-primitive data' }
 TostMaterializationTests >> testReadingTwoBytesInteger [
 	| actual |
-	self
-		binaryData:
-			{2.
-			0.
-			(300 byteAt: 2).
-			(300 byteAt: 1)}.
+	self binaryData: {2. 0. (300 byteAt: 2). (300 byteAt: 1)}.
 	actual := materializer readInteger.
 	actual should equal: 300
 ]
@@ -498,12 +493,7 @@ TostMaterializationTests >> testReadingTwoBytesInteger [
 { #category : #'tests-primitive data' }
 TostMaterializationTests >> testReadingTwoBytesNegativeInteger [
 	| actual |
-	self
-		binaryData:
-			{2.
-			1.
-			(300 byteAt: 2).
-			(300 byteAt: 1)}.
+	self binaryData: {2. 1. (300 byteAt: 2). (300 byteAt: 1)}.
 	actual := materializer readInteger.
 	actual should equal: -300
 ]
@@ -511,11 +501,7 @@ TostMaterializationTests >> testReadingTwoBytesNegativeInteger [
 { #category : #'tests-primitive data' }
 TostMaterializationTests >> testReadingTwoBytesPositiveInteger [
 	| actual |
-	self
-		binaryData:
-			{2.
-			(300 byteAt: 2).
-			(300 byteAt: 1)}.
+	self binaryData: {2. (300 byteAt: 2). (300 byteAt: 1)}.
 	actual := materializer readPositiveInteger.
 	actual should equal: 300
 ]

--- a/TostSerializer-Tests/TostSerializationTests.class.st
+++ b/TostSerializer-Tests/TostSerializationTests.class.st
@@ -183,31 +183,17 @@ TostSerializationTests >> testWritingOneByteInteger [
 { #category : #'tests-primitive data' }
 TostSerializationTests >> testWritingTwoBytesInteger [
 	serialization writeInteger: 300.
-	self binaryData should
-		equal:
-			{2.
-			0.
-			(300 byteAt: 2).
-			(300 byteAt: 1)} asByteArray
+	self binaryData should equal: {2. 0. (300 byteAt: 2). (300 byteAt: 1)} asByteArray
 ]
 
 { #category : #'tests-primitive data' }
 TostSerializationTests >> testWritingTwoBytesNegativeInteger [
 	serialization writeInteger: -300.
-	self binaryData should
-		equal:
-			{2.
-			1.
-			(300 byteAt: 2).
-			(300 byteAt: 1)} asByteArray
+	self binaryData should equal: {2. 1. (300 byteAt: 2). (300 byteAt: 1)} asByteArray
 ]
 
 { #category : #'tests-primitive data' }
 TostSerializationTests >> testWritingTwoBytesPositiveInteger [
 	serialization writePositiveInteger: 300.
-	self binaryData should
-		equal:
-			{2.
-			(300 byteAt: 2).
-			(300 byteAt: 1)} asByteArray
+	self binaryData should equal: {2. (300 byteAt: 2). (300 byteAt: 1)} asByteArray
 ]

--- a/TostSerializer-Tests/TostSerializationTests.class.st
+++ b/TostSerializer-Tests/TostSerializationTests.class.st
@@ -6,7 +6,7 @@ Class {
 		'dataStream',
 		'binaryData'
 	],
-	#category : 'TostSerializer-Tests'
+	#category : #'TostSerializer-Tests'
 }
 
 { #category : #helpers }
@@ -182,24 +182,32 @@ TostSerializationTests >> testWritingOneByteInteger [
 
 { #category : #'tests-primitive data' }
 TostSerializationTests >> testWritingTwoBytesInteger [
-
 	serialization writeInteger: 300.
-	
-	self binaryData should equal: {2. 0. 300 digitAt: 2. 300 digitAt: 1} asByteArray
+	self binaryData should
+		equal:
+			{2.
+			0.
+			(300 byteAt: 2).
+			(300 byteAt: 1)} asByteArray
 ]
 
 { #category : #'tests-primitive data' }
 TostSerializationTests >> testWritingTwoBytesNegativeInteger [
-
 	serialization writeInteger: -300.
-	
-	self binaryData should equal: {2. 1. 300 digitAt: 2. 300 digitAt: 1} asByteArray 
+	self binaryData should
+		equal:
+			{2.
+			1.
+			(300 byteAt: 2).
+			(300 byteAt: 1)} asByteArray
 ]
 
 { #category : #'tests-primitive data' }
 TostSerializationTests >> testWritingTwoBytesPositiveInteger [
-
 	serialization writePositiveInteger: 300.
-	
-	self binaryData should equal: {2. 300 digitAt: 2. 300 digitAt: 1} asByteArray 
+	self binaryData should
+		equal:
+			{2.
+			(300 byteAt: 2).
+			(300 byteAt: 1)} asByteArray
 ]

--- a/TostSerializer/Integer.extension.st
+++ b/TostSerializer/Integer.extension.st
@@ -1,6 +1,18 @@
 Extension { #name : #Integer }
 
 { #category : #'*TostSerializer' }
+Integer >> byteAt: anInteger [
+	"Compatibility with Pharo7. In Pharo8/9 #digitAt: was changed to #byteAt:"
+	^ self digitAt: anInteger
+]
+
+{ #category : #'*TostSerializer' }
+Integer >> bytesCount [
+	"Compatibility with Pharo7. In Pharo8/9 #digitLength was changed to #bytesCount"
+	^ self digitLength
+]
+
+{ #category : #'*TostSerializer' }
 Integer class >> createTostInstanceWith: aTostMaterialization [
 	^aTostMaterialization readInteger 
 ]

--- a/TostSerializer/TostSerialization.class.st
+++ b/TostSerializer/TostSerialization.class.st
@@ -16,7 +16,7 @@ Public API and Key Messages
 Class {
 	#name : #TostSerialization,
 	#superclass : #TostTransportation,
-	#category : 'TostSerializer'
+	#category : #TostSerializer
 }
 
 { #category : #api }
@@ -72,14 +72,9 @@ TostSerialization >> writeDuplicatedObject: anObject format: formatId [
 TostSerialization >> writeInteger: anInteger [
 	| bytesSize |
 	bytesSize := anInteger bytesCount.
-	bytesSize > 255
-		ifTrue: [ self error: 'Too big integer is not supported' ].
+	bytesSize > 255 ifTrue: [ self error: 'Too big integer is not supported' ].
 	dataStream nextPut: bytesSize.
-	dataStream
-		nextPut:
-			(anInteger < 0
-				ifTrue: [ 1 ]
-				ifFalse: [ 0 ]).
+	dataStream nextPut: (anInteger < 0 ifTrue: [ 1 ] ifFalse: [ 0 ]).
 	bytesSize to: 1 by: -1 do: [ :i | dataStream nextPut: (anInteger byteAt: i) ]
 ]
 
@@ -115,11 +110,9 @@ TostSerialization >> writeObjectIndex: objectIdInteger format: binaryTypeByte [
 { #category : #'writing-primitive data' }
 TostSerialization >> writePositiveInteger: anInteger [
 	| bytesSize |
-	anInteger < 0
-		ifTrue: [ self error: 'Given int should be positive' ].
+	anInteger < 0 ifTrue: [ self error: 'Given int should be positive' ].
 	bytesSize := anInteger bytesCount.
-	bytesSize > 255
-		ifTrue: [ self error: 'Too big integer is not supported' ].
+	bytesSize > 255 ifTrue: [ self error: 'Too big integer is not supported' ].
 	dataStream nextPut: bytesSize.
 	bytesSize to: 1 by: -1 do: [ :i | dataStream nextPut: (anInteger byteAt: i) ]
 ]

--- a/TostSerializer/TostSerialization.class.st
+++ b/TostSerializer/TostSerialization.class.st
@@ -16,7 +16,7 @@ Public API and Key Messages
 Class {
 	#name : #TostSerialization,
 	#superclass : #TostTransportation,
-	#category : 'TostSerializer'
+	#category : #TostSerializer
 }
 
 { #category : #api }
@@ -70,15 +70,17 @@ TostSerialization >> writeDuplicatedObject: anObject format: formatId [
 
 { #category : #'writing-primitive data' }
 TostSerialization >> writeInteger: anInteger [
-
 	| bytesSize |
-	bytesSize := anInteger digitLength.
-	bytesSize > 255 ifTrue: [ self error: 'Too big integer is not supported' ].
-	
+	bytesSize := anInteger bytesCount.
+	bytesSize > 255
+		ifTrue: [ self error: 'Too big integer is not supported' ].
 	dataStream nextPut: bytesSize.
-	dataStream nextPut: (anInteger < 0 ifTrue: [1] ifFalse: [ 0 ]).
-	bytesSize to: 1 by: -1 do: [ :i |
-		dataStream nextPut: (anInteger digitAt: i) ]
+	dataStream
+		nextPut:
+			(anInteger < 0
+				ifTrue: [ 1 ]
+				ifFalse: [ 0 ]).
+	bytesSize to: 1 by: -1 do: [ :i | dataStream nextPut: (anInteger byteAt: i) ]
 ]
 
 { #category : #'writing-objects' }
@@ -112,15 +114,14 @@ TostSerialization >> writeObjectIndex: objectIdInteger format: binaryTypeByte [
 
 { #category : #'writing-primitive data' }
 TostSerialization >> writePositiveInteger: anInteger [
-
 	| bytesSize |
-	anInteger < 0 ifTrue: [ self error: 'Given int should be positive' ].
-	bytesSize := anInteger digitLength.
-	bytesSize > 255 ifTrue: [ self error: 'Too big integer is not supported' ].
-	
+	anInteger < 0
+		ifTrue: [ self error: 'Given int should be positive' ].
+	bytesSize := anInteger bytesCount.
+	bytesSize > 255
+		ifTrue: [ self error: 'Too big integer is not supported' ].
 	dataStream nextPut: bytesSize.
-	bytesSize to: 1 by: -1 do: [ :i |
-		dataStream nextPut: (anInteger digitAt: i) ]
+	bytesSize to: 1 by: -1 do: [ :i | dataStream nextPut: (anInteger byteAt: i) ]
 ]
 
 { #category : #'writing-objects' }

--- a/TostSerializer/TostSerialization.class.st
+++ b/TostSerializer/TostSerialization.class.st
@@ -16,7 +16,7 @@ Public API and Key Messages
 Class {
 	#name : #TostSerialization,
 	#superclass : #TostTransportation,
-	#category : #TostSerializer
+	#category : 'TostSerializer'
 }
 
 { #category : #api }


### PR DESCRIPTION
There are 3 tests not passing:

#testBlockClosureWithContex
#testBlockClosureWithoutContext
#testCompiledMethod

How can I fix them?