### PR TITLE
Pharo 9 compatibility with FullBlockClosure support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ smalltalk:
   - Pharo64-7.0
   - Pharo32-8.0
   - Pharo64-8.0
+  - Pharo32-9.0
+  - Pharo64-9.0

--- a/BaselineOfTostSerializer/BaselineOfTostSerializer.class.st
+++ b/BaselineOfTostSerializer/BaselineOfTostSerializer.class.st
@@ -13,7 +13,7 @@ BaselineOfTostSerializer >> baseline: spec [
 				spec repository: 'github://dionisiydk/StateSpecs:v4.0.2'];
 			baseline: 'ObjectTravel' with: [
 				spec
-					repository: 'github://pharo-ide/ObjectTravel:v1.0.2';
+					repository: 'github://pharo-ide/ObjectTravel:v1.0.3';
 					loads: 'Core' ];
 			project: 'ObjectTravelTests' copyFrom: 'ObjectTravel' with: [
 				spec loads: 'Tests'].

--- a/TostSerializer-Tests/TostMaterializationTests.class.st
+++ b/TostSerializer-Tests/TostMaterializationTests.class.st
@@ -67,10 +67,11 @@ TostMaterializationTests >> testBlockClosureWithContex [
 	block := [temp + 2 ].
 	transport addFirstFormat: (TostWellKnownObjectFormat on: {self. self class >> testSelector. thisContext sender}).
 	self serialize: block.
-	
+
 	actual := transporter materializeObject.
 	
-	actual should beInstanceOf: BlockClosure.
+	actual should beKindOf: BlockClosure.
+	actual class should be: block class.
 	actual value should equal: temp + 2
 ]
 
@@ -81,11 +82,13 @@ TostMaterializationTests >> testBlockClosureWithoutContext [
 	temp := 10.
 	block := [temp + 2 ].
 	transport addFirstFormat: (TostWellKnownObjectFormat on: {self. self class >> testSelector. thisContext}).
+
 	self serialize: block.
 	
 	actual := transporter materializeObject.
 	
-	actual should beInstanceOf: BlockClosure.
+	actual should beKindOf: BlockClosure.
+	actual class should be: block class.
 	actual value should equal: temp + 2
 ]
 
@@ -587,11 +590,56 @@ TostMaterializationTests >> testWellKnownEmptyObject [
 	| actual object |
 	object := Object new.
 	transport addFirstFormat: (TostWellKnownObjectFormat on: {2@3. object. 10@30}).
+	self serialize: {object}.
+	
+	actual := transporter materializeObject.
+	
+	actual should beInstanceOf: Array.
+	actual first should beInstanceOf: Object.
+	actual first should be: object
+]
+
+{ #category : #'tests-objects' }
+TostMaterializationTests >> testWellKnownEmptyRootObject [
+
+	| actual object |
+	object := Object new.
+	transport addFirstFormat: (TostWellKnownObjectFormat on: {object}).
 	self serialize: object.
 	
 	actual := transporter materializeObject.
 	
-	actual should beInstanceOf: Object
+	actual should beInstanceOf: Object.
+	actual should be: object
+]
+
+{ #category : #'tests-objects' }
+TostMaterializationTests >> testWellKnownNonEmptyObjectInsideContainer [
+
+	| actual array container |
+	array := #(1 2) copy. "copy is to avoid posible change of literal state in case of broken test"
+	container := {array. #(3 4) copy}.
+	transport addFirstFormat: (TostWellKnownObjectFormat on: {array}).
+	self serialize: container.
+	
+	actual := transporter materializeObject.
+	
+	actual should equal: container.
+	array should equal: #(1 2) copy.
+]
+
+{ #category : #'tests-objects' }
+TostMaterializationTests >> testWellKnownNonEmptyRootObject [
+
+	| actual object |
+	object := #(1 2) copy.
+	transport addFirstFormat: (TostWellKnownObjectFormat on: {object}).
+	
+	self serialize: object.	
+	actual := transporter materializeObject.
+	
+	actual should be: object.
+	actual should equal: #(1 2) copy
 ]
 
 { #category : #'tests-objects' }

--- a/TostSerializer-Tests/TostMaterializationTests.class.st
+++ b/TostSerializer-Tests/TostMaterializationTests.class.st
@@ -29,7 +29,7 @@ TostMaterializationTests >> serializeAll: objects [
 	| serializer |
 	transportStream reset.
 	serializer := TostTransporter using: transport on: transportStream.	
-	objects do: [:each | serializer serialize: each].
+	objects do: [:each | serializer serializeObject: each].
 	transportStream reset
 ]
 
@@ -233,6 +233,23 @@ TostMaterializationTests >> testIntegerInstanceOf4Bytes [
 	actual := transporter materializeObject.
 	
 	actual should equal: 300000000
+]
+
+{ #category : #'tests-objects' }
+TostMaterializationTests >> testInternalDictionaryAsLastChild [
+	| dict actual key1 key2 container |
+	dict := Dictionary newFrom: {Object new -> #item1. Object new -> #item2}.
+	container := TostTestContainer with: dict.
+	self serialize: container.	
+		
+	actual := transporter materializeObject content.
+	
+	actual should beInstanceOf: Dictionary.
+	"dictionary should be rehashed after materialization. So each key can access own value"
+	key1 := actual keyAtValue: #item1.
+	key2 := actual keyAtValue: #item2.
+	actual should include: #item1 at: key1.
+	actual should include: #item2 at: key2.
 ]
 
 { #category : #'tests-objects' }

--- a/TostSerializer-Tests/TostSerializationTests.class.st
+++ b/TostSerializer-Tests/TostSerializationTests.class.st
@@ -159,6 +159,19 @@ TostSerializationTests >> testWellKnownEmptyObject [
 	self binaryData should equal: {extraFormat id. 2} asByteArray
 ]
 
+{ #category : #'tests-objects' }
+TostSerializationTests >> testWellKnownNonEmptyRootObject [
+
+	| extraFormat object |
+	object := #(1 2) copy.
+	extraFormat := TostWellKnownObjectFormat on: {object}.
+	transport addFirstFormat: extraFormat.
+	
+	transporter serialize: object.
+	
+	self binaryData should equal: {extraFormat id. 1} asByteArray
+]
+
 { #category : #'tests-primitive data' }
 TostSerializationTests >> testWritingByteArray [
 

--- a/TostSerializer-Tests/TostSerializationTests.class.st
+++ b/TostSerializer-Tests/TostSerializationTests.class.st
@@ -28,9 +28,9 @@ TostSerializationTests >> testByteArrayInstance [
 
 	| object |
 	object := #[1 2 5 10].
-	transporter serialize: object.
+	transporter serializeObject: object.
 	self clearData.
-	transporter serialize: object copy.
+	transporter serializeObject: object copy.
 	
 	self binaryData should equal: {
 		transport formatIdFor: TostNewObjectOfDuplicatedClassFormat. 
@@ -44,7 +44,7 @@ TostSerializationTests >> testEmptyObject [
 
 	| object classNameBytes classNameSizeBytes |
 	object := Object new.
-	transporter serialize: object.
+	transporter serializeObject: object.
 	classNameBytes := Object name asByteArray.
 	classNameSizeBytes := #[1], classNameBytes size asByteArray.
 	
@@ -57,7 +57,7 @@ TostSerializationTests >> testObjectAndItClass [
 	| object |
 	object := Object new.
 	transporter writeBytes: #[ 1 2 3 4 ].
-	transporter serialize: Object new.
+	transporter serializeObject: Object new.
 	self clearData.
 	transporter writeObject: Object.
 	
@@ -71,7 +71,7 @@ TostSerializationTests >> testObjectOfWellKnownClass [
 	extraFormat := TostNewObjectOfWellKnownClassFormat on: { Point. Object. Array }.
 	transport addFirstFormat: extraFormat.
 	
-	transporter serialize: Object new.
+	transporter serializeObject: Object new.
 	
 	self binaryData should equal: {extraFormat id. 2} asByteArray
 ]
@@ -82,9 +82,9 @@ TostSerializationTests >> testSameObjectTwice [
 	| object |
 	object := Object new.
 	transporter writeBytes: #[1 2 3 4]. "index of following object should be equal stream position (4)"
-	transporter serialize: object.
+	transporter serializeObject: object.
 	self clearData.
-	transporter serialize: object.
+	transporter serializeObject: object.
 	
 	self binaryData should equal: ({transport formatIdFor: TostDuplicatedObjectFormat}, #[1 4]) asByteArray
 ]
@@ -95,10 +95,10 @@ TostSerializationTests >> testThreeObjectsOfSameClassWhereFirstTwoAreSame [
 	| object |
 	object := Object new.
 	transporter writeBytes: #[ 1 2 3 4 ].
-	transporter serialize: object.
-	transporter serialize: object.
+	transporter serializeObject: object.
+	transporter serializeObject: object.
 	self clearData.
-	transporter serialize: Object new.
+	transporter serializeObject: Object new.
 	
 	self binaryData should equal: {transport formatIdFor: TostNewObjectOfDuplicatedClassFormat. 1. 4} asByteArray 
 ]
@@ -109,11 +109,11 @@ TostSerializationTests >> testThreeObjectsOfSameClassWhereLastTwoAreSame [
 	| object objectIndex |
 	object := Object new.
 	transporter writeBytes: #[ 1 2 3 4 ].
-	transporter serialize: Object new.
+	transporter serializeObject: Object new.
 	objectIndex := transporter transportStream position.
-	transporter serialize: object.
+	transporter serializeObject: object.
 	self clearData.
-	transporter serialize: object.
+	transporter serializeObject: object.
 	
 	self binaryData should equal: {transport formatIdFor: TostDuplicatedObjectFormat. 1. objectIndex} asByteArray 
 ]
@@ -124,10 +124,10 @@ TostSerializationTests >> testTwoObjectsOfSameClass [
 	| object |
 	object := Object new.
 	transporter writeBytes: #[ 1 2 3 4 ].
-	transporter serialize: Object new.
+	transporter serializeObject: Object new.
 	self clearData.
 
-	transporter serialize: Object new.
+	transporter serializeObject: Object new.
 	
 	self binaryData should equal: {transport formatIdFor: TostNewObjectOfDuplicatedClassFormat. 1. 4} asByteArray 
 ]
@@ -141,7 +141,7 @@ TostSerializationTests >> testWellKnownCompositeObject [
 	transport addFirstFormat: (TostNewObjectOfWellKnownClassFormat on: {TostTestContainer}).
 	extraFormat := TostWellKnownObjectFormat on: {2@3. object. 10@30 }.
 	transport addFirstFormat: extraFormat.
-	transporter serialize: container.
+	transporter serializeObject: container.
 	
 	self binaryData should equal: {2. 1. extraFormat id. 2} asByteArray
 ]
@@ -154,7 +154,7 @@ TostSerializationTests >> testWellKnownEmptyObject [
 	extraFormat := TostWellKnownObjectFormat on: {2@3. object. 10@30 }.
 	transport addFirstFormat: extraFormat.
 	
-	transporter serialize: object.
+	transporter serializeObject: object.
 	
 	self binaryData should equal: {extraFormat id. 2} asByteArray
 ]
@@ -167,7 +167,7 @@ TostSerializationTests >> testWellKnownNonEmptyRootObject [
 	extraFormat := TostWellKnownObjectFormat on: {object}.
 	transport addFirstFormat: extraFormat.
 	
-	transporter serialize: object.
+	transporter serializeObject: object.
 	
 	self binaryData should equal: {extraFormat id. 1} asByteArray
 ]

--- a/TostSerializer/CompiledCode.extension.st
+++ b/TostSerializer/CompiledCode.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : #CompiledMethod }
+Extension { #name : #CompiledCode }
 
 { #category : #'*TostSerializer' }
-CompiledMethod class >> createTostInstanceWith: aTostTransporter [
+CompiledCode class >> createTostInstanceWith: aTostTransporter [
 
 	| size bytecodes method header numLiterals wordSize literalSize newLiteralSize |
 	size := aTostTransporter readPositiveInteger.
@@ -23,7 +23,7 @@ CompiledMethod class >> createTostInstanceWith: aTostTransporter [
 ]
 
 { #category : #'*TostSerializer' }
-CompiledMethod >> writeTostBodyWith: aTostTransporter [
+CompiledCode >> writeTostBodyWith: aTostTransporter [
 	| bytecodes initialPC |
 	initialPC := self initialPC.
 	bytecodes := ByteArray new: self size - initialPC + 1.

--- a/TostSerializer/FullBlockClosure.extension.st
+++ b/TostSerializer/FullBlockClosure.extension.st
@@ -1,0 +1,23 @@
+Extension { #name : #FullBlockClosure }
+
+{ #category : #'*TostSerializer' }
+FullBlockClosure >> correctTostMaterializationWith: materializedWordSize [
+	"FullBlockClosure has no difference in binary presentation in 32 and 64 bit images.
+	Therefore nothing to do here"
+]
+
+{ #category : #'*TostSerializer' }
+FullBlockClosure class >> createTostInstanceWith: aTostTransporter [
+	"FullBlockClosure has no difference in binary presentation in 32 and 64 bit images.
+	Therefore the instantiation method here is simplified to Object version"
+	
+	^self basicNew: aTostTransporter readPositiveInteger
+]
+
+{ #category : #'*TostSerializer' }
+FullBlockClosure >> writeTostBodyWith: aTostTransporter [
+ 	"FullBlockClosure has no difference in binary presentation in 32 and 64 bit images.
+	Therefore the serialization method here is simplified to Object version"
+
+	aTostTransporter writePositiveInteger: self size
+]

--- a/TostSerializer/TostTransport.class.st
+++ b/TostSerializer/TostTransport.class.st
@@ -140,7 +140,7 @@ TostTransport >> sendObject: anObject to: transportStream [
 
 	| transporter |
 	transporter := self newTransporterOn: transportStream.
-	transporter serialize: anObject
+	transporter serializeObject: anObject
 ]
 
 { #category : #operations }

--- a/TostSerializer/TostTransporter.class.st
+++ b/TostSerializer/TostTransporter.class.st
@@ -102,17 +102,12 @@ TostTransporter >> materializeObject [
 		^object ].
 	traveler startOn: object.			
 				
-	[ transportStream atEnd not and: [traveler moveToNextReference]] whileTrue: [ 
+	[ transportStream atEnd not & traveler moveToNextReference] whileTrue: [
+		"& is to always complete traversal at the end of stream when traveler is at some leaf child"
 		newObject := self readNextObject.	
 		traveler replaceCurrentReferenceWith: newObject
 	 ].
-
-	"While there are no other references under traversal route
-	the traveler points to the last leaf child node which can be inside deep children tree.
-	So the next step here is to leave all of them	to signal their materialization completion"
-	traveler moveToNextReference. 
-	"But the root object is never left the trafersal 
-	and therefore we should complete the materialization of the root manually"
+	"Еhe root object is never left the trafersal and therefore the manual completion is erquired"
 	self completeMaterializationOf: object. 
 	^object
 ]
@@ -230,7 +225,7 @@ TostTransporter >> readString: stringClass [
 ]
 
 { #category : #api }
-TostTransporter >> serialize: anObject [
+TostTransporter >> serializeObject: anObject [
 
 	traveler := ObjectTraveler new.	
 	self writeNextObject: anObject.	

--- a/TostSerializer/TostTransporter.class.st
+++ b/TostSerializer/TostTransporter.class.st
@@ -93,17 +93,27 @@ TostTransporter >> initialize [
 { #category : #api }
 TostTransporter >> materializeObject [
 	| newObject object |	
+	traveler := ObjectTraveler new.
+	traveler whenLeaveNodeDo: [:node | self completeMaterializationOf: node ].	
 	object := self readNextObject.
-	traveler := ObjectTraveler on: object.
-	traveler whenLeaveNodeDo: [:node | self completeMaterializationOf: node ].
-
+	(traveler isTraversed: object) ifTrue: [ 
+		"The initial read of root object marks it as completely processed.
+		So nothing else needs to be done with it"
+		^object ].
+	traveler startOn: object.			
+				
 	[ transportStream atEnd not and: [traveler moveToNextReference]] whileTrue: [ 
 		newObject := self readNextObject.	
 		traveler replaceCurrentReferenceWith: newObject
 	 ].
 
-	traveler moveToNextReference. "it should leave all deep children nodes and signal post processing"
-	self completeMaterializationOf: object. "root traversed object is never left"
+	"While there are no other references under traversal route
+	the traveler points to the last leaf child node which can be inside deep children tree.
+	So the next step here is to leave all of them	to signal their materialization completion"
+	traveler moveToNextReference. 
+	"But the root object is never left the trafersal 
+	and therefore we should complete the materialization of the root manually"
+	self completeMaterializationOf: object. 
 	^object
 ]
 
@@ -222,10 +232,14 @@ TostTransporter >> readString: stringClass [
 { #category : #api }
 TostTransporter >> serialize: anObject [
 
-	traveler := ObjectTraveler on: anObject.
-	
+	traveler := ObjectTraveler new.	
 	self writeNextObject: anObject.	
-		
+	(traveler isTraversed: anObject) ifTrue: [ 
+		"The initial write of root object marks it as completely processed.
+		So nothing else needs to be done with it"
+		^self ].
+	traveler startOn: anObject.
+	
 	traveler referencesDo: [ :each | 
 		self writeNextObject: each ]
 ]

--- a/TostSerializer/TostWellKnownObjectFormat.class.st
+++ b/TostSerializer/TostWellKnownObjectFormat.class.st
@@ -14,7 +14,7 @@ Class {
 	#classInstVars : [
 		'default'
 	],
-	#category : 'TostSerializer'
+	#category : #TostSerializer
 }
 
 { #category : #accessing }
@@ -24,9 +24,11 @@ TostWellKnownObjectFormat class >> default [
 
 { #category : #operations }
 TostWellKnownObjectFormat >> readObjectWith: aTostTransporter [ 
-	| objectIndex |
+	| objectIndex foundObject |
 	objectIndex := aTostTransporter readByte.
-	^objects at: objectIndex
+	foundObject := objects at: objectIndex.
+	aTostTransporter skip: foundObject.
+	^foundObject
 ]
 
 { #category : #operations }

--- a/TostSerializer/TostWellKnownObjectFormat.class.st
+++ b/TostSerializer/TostWellKnownObjectFormat.class.st
@@ -14,7 +14,7 @@ Class {
 	#classInstVars : [
 		'default'
 	],
-	#category : #TostSerializer
+	#category : 'TostSerializer'
 }
 
 { #category : #accessing }


### PR DESCRIPTION
Full block support is done by pushing CompiledMethod extensions into CompiledCode and making FullBlockClosure extensions to use Object versions instead of BlockClosure which is not needed there.
(Special logic in BlockClosure is to transparently support 32 and 64 bits images. New full blocks have no difference in these platforms).

In addition critical bug is fixed with WellKnownObjectFormat. Previous version was able to override the state of found global object with next state read from the transport stream. 

Transporter API is changed for consistency:
- serializeObject:
- materializeObject

And several other insignificant fixes related to root object serialization and materialization